### PR TITLE
Break out parameters held in the page_location query string

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,6 @@
 # TODO
 
 - handle `debug_mode` param (filter out?)
-- parse out stem and query string from `page_location` URL
 - bring user properties into `dim_ga4__users` (variable containing a list of user properties?)
 - mechanism to take in an array variable listing custom events and output 1 model per event (is this possible?)
 - move all common event params to `base_ga4__events`

--- a/macros/extract_query_string_from_url.sql
+++ b/macros/extract_query_string_from_url.sql
@@ -1,0 +1,4 @@
+
+{% macro extract_query_string_from_url(url) %}
+    REGEXP_EXTRACT({{ url }}, '\\?(.+)')
+{% endmacro %}

--- a/models/staging/ga4/stg_ga4.yml
+++ b/models/staging/ga4/stg_ga4.yml
@@ -3,6 +3,8 @@ version: 2
 models:  
   - name: base_ga4__events
     description: Base events model that pulls all fields from raw data. Resulting table is partitioned on event_date and is useful in that BQ queries can be cached against this table, but not against wildcard searches from the original tables which are sharded on date. Some light transformation and renaming beyond the base events model. Adds surrogate keys for sessions and events
+  - name: stg_ga4__event_to_query_string_params
+    description: This model pivots the query string parameters contained within the event's page_location field to become rows. Each row is a single parameter/value combination contained in a single event's query string.
   - name: stg_ga4__event_page_view
     description: GA4 events filtered to only show 'page_view' events. Pivots common event parameters into separate columns. Identifies the first and last pageview in the 'is_entrance' and 'is_exit' columns. 
   - name: stg_ga4__event_session_start

--- a/models/staging/ga4/stg_ga4__event_to_query_string_params.sql
+++ b/models/staging/ga4/stg_ga4__event_to_query_string_params.sql
@@ -1,0 +1,24 @@
+with event_and_query_string as 
+(
+    select 
+        event_key,
+        split(page_query_string, '&') as qs_split
+    from {{ref('stg_ga4__events')}}
+),
+flattened_qs as
+(
+    select 
+        event_key, 
+        params 
+    from event_and_query_string, unnest(qs_split) as params
+),
+split_param_value as 
+(
+    select 
+        event_key, 
+        split(params,'=')[SAFE_OFFSET(0)] as param, 
+        split(params,'=')[SAFE_OFFSET(1)] as value 
+    from flattened_qs
+)
+
+select * from split_param_value

--- a/models/staging/ga4/stg_ga4__events.sql
+++ b/models/staging/ga4/stg_ga4__events.sql
@@ -24,7 +24,8 @@ include_event_key as (
 enrich_params as (
     select 
         include_event_key.*,
-        {{extract_hostname_from_url('page_location')}} as page_hostname
+        {{extract_hostname_from_url('page_location')}} as page_hostname,
+        {{extract_query_string_from_url('page_location')}} as page_query_string,
     from include_event_key
 )
 


### PR DESCRIPTION
Created `stg_ga4__event_to_query_string_params` which is a mapping between an event_key and every query string parameter/value combination held in the event's `page_location` field.

This can be used to pull out `gclid` values or to understand if a user has ever interacted with a certain utm_source/campaign.