### PR TITLE
Include support for intraday events

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -35,7 +35,6 @@
 - Test whether session keys are unique
 - Add integration tests - Need to think about how to handle nested data as the source. CSV won't reproduce nested data. 
     - Look into using https://github.com/EqualExperts/dbt-unit-testing and generating mock data using SQL statements. 
-- intraday support
 - Any special considerations for handling >1 data stream? 
 - Set dynamic vs. static partitioning using a variable
 - Seed file for channel group mapping

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -13,12 +13,12 @@ clean-targets:         # directories to be removed by `dbt clean`
   - "target"
   - "dbt_packages"
 
-profile: obfuscated_test_db
+#vars:
+#    start_date: "20210120" # Defines the earliest GA4 _TABLE_SUFFIX to load into base events model. 
+#    project: "bigquery-public-data"
+#    dataset: "ga4_obfuscated_sample_ecommerce"
+#    include_intraday_events: true|false # indicates whether intraday events should be unioned into the event model
 
-vars:
-    start_date: "20210120" # Defines the earliest GA4 _TABLE_SUFFIX to load into base events model. 
-    project: "bigquery-public-data"
-    dataset: "ga4_obfuscated_sample_ecommerce"
 # custom parameters are registered by creating a var matching the event name where the custom parameter occurs
 # and providing the name, matching the parameters name
 # and matching the value_type to the type of column in BigQuery (string_value, int_value, float_value, double_value)

--- a/models/staging/ga4/base/base_ga4__events.sql
+++ b/models/staging/ga4/base/base_ga4__events.sql
@@ -35,7 +35,7 @@ with source as (
         ecommerce,
         items
     from {{ source('ga4', 'events') }}
-    where _table_suffix not like '%intraday%' and -- TODO: support blending intraday events as well
+    where _table_suffix not like '%intraday%' and -- intraday events are supported through the project variable: include_intraday_events
         cast(_table_suffix as int64) >= {{var('start_date')}}
     {% if is_incremental() %}
         -- Incrementally add new events. Filters on _TABLE_SUFFIX using the max event_date_dt value found in {{this}}

--- a/models/staging/ga4/base/base_ga4__events_intraday.sql
+++ b/models/staging/ga4/base/base_ga4__events_intraday.sql
@@ -2,6 +2,7 @@
   enabled= var('include_intraday_events', false) 
 ) }}
 
+-- This model will be unioned with `base_ga4__events` which means that their columns must match
 
 with source as (
     select 

--- a/models/staging/ga4/base/base_ga4__events_intraday.sql
+++ b/models/staging/ga4/base/base_ga4__events_intraday.sql
@@ -1,0 +1,71 @@
+
+{% if var('include_intraday_events', 'true') == 'true' %}
+with source as (
+    select 
+        parse_date('%Y%m%d',event_date) as event_date_dt,
+        event_timestamp,
+        event_name,
+        event_params,
+        event_previous_timestamp,
+        event_value_in_usd,
+        event_bundle_sequence_id,
+        event_server_timestamp_offset,
+        user_id,
+        user_pseudo_id as client_id,
+        privacy_info,
+        user_properties,
+        user_first_touch_timestamp,
+        user_ltv,
+        device,
+        geo,
+        app_info,
+        traffic_source,
+        stream_id,
+        platform,
+        ecommerce,
+        items
+    from {{ source('ga4', 'events_intraday') }}
+),
+renamed as (
+    select 
+        event_date_dt,
+        event_timestamp,
+        lower(replace(trim(event_name), " ", "_")) as event_name, -- Clean up all event names to be snake cased
+        event_params,
+        event_previous_timestamp,
+        event_value_in_usd,
+        event_bundle_sequence_id,
+        event_server_timestamp_offset,
+        user_id,
+        client_id,
+        privacy_info,
+        user_properties,
+        user_first_touch_timestamp,
+        user_ltv,
+        device,
+        geo,
+        app_info,
+        traffic_source,
+        stream_id,
+        platform,
+        ecommerce,
+        items,
+        {{ unnest_key('event_params', 'ga_session_id', 'int_value') }},
+        {{ unnest_key('event_params', 'page_location') }},
+        {{ unnest_key('event_params', 'ga_session_number',  'int_value') }},
+        {{ unnest_key('event_params', 'session_engaged', 'int_value') }},
+        {{ unnest_key('event_params', 'page_title') }},
+        {{ unnest_key('event_params', 'page_referrer') }},
+        CASE 
+            WHEN event_name = 'page_view' THEN 1
+            ELSE 0
+        END AS is_page_view,
+        CASE 
+            WHEN event_name = 'purchase' THEN 1
+            ELSE 0
+        END AS is_purchase
+    from source
+)
+
+select * from renamed
+{% endif %}

--- a/models/staging/ga4/base/base_ga4__events_intraday.sql
+++ b/models/staging/ga4/base/base_ga4__events_intraday.sql
@@ -1,5 +1,8 @@
+{{ config(
+  enabled= var('include_intraday_events', 'true') 
+) }}
 
-{% if var('include_intraday_events', 'true') == 'true' %}
+
 with source as (
     select 
         parse_date('%Y%m%d',event_date) as event_date_dt,
@@ -68,4 +71,3 @@ renamed as (
 )
 
 select * from renamed
-{% endif %}

--- a/models/staging/ga4/base/base_ga4__events_intraday.sql
+++ b/models/staging/ga4/base/base_ga4__events_intraday.sql
@@ -1,5 +1,5 @@
 {{ config(
-  enabled= var('include_intraday_events', 'true') 
+  enabled= var('include_intraday_events', false) 
 ) }}
 
 

--- a/models/staging/ga4/src_ga4.yml
+++ b/models/staging/ga4/src_ga4.yml
@@ -7,4 +7,5 @@ sources:
     tables:
       - name: events
         identifier: events_* # Scan across all sharded event tables. Use the 'start_date' variable to limit this scan
-
+      - name: events_intraday
+        identifier: events_intraday_*

--- a/models/staging/ga4/stg_ga4.yml
+++ b/models/staging/ga4/stg_ga4.yml
@@ -3,6 +3,8 @@ version: 2
 models:  
   - name: base_ga4__events
     description: Base events model that pulls all fields from raw data. Resulting table is partitioned on event_date and is useful in that BQ queries can be cached against this table, but not against wildcard searches from the original tables which are sharded on date. Some light transformation and renaming beyond the base events model. Adds surrogate keys for sessions and events
+  - name: base_ga4__events_intraday
+    description: Base model for intraday events that will be unioned to the past events stored in the incremental model. 
   - name: stg_ga4__event_to_query_string_params
     description: This model pivots the query string parameters contained within the event's page_location field to become rows. Each row is a single parameter/value combination contained in a single event's query string.
   - name: stg_ga4__event_page_view

--- a/models/staging/ga4/stg_ga4__events.sql
+++ b/models/staging/ga4/stg_ga4__events.sql
@@ -2,6 +2,10 @@
 
 with base_events as (
     select * from {{ ref('base_ga4__events')}}
+    {% if var('include_intraday_events', 'true') == 'true' %}
+    union all
+    select * from {{ref('base_ga4__events_intraday')}}
+    {% endif %}
 ),
 -- Add unique keys for sessions and events
 include_session_key as (

--- a/models/staging/ga4/stg_ga4__events.sql
+++ b/models/staging/ga4/stg_ga4__events.sql
@@ -2,7 +2,7 @@
 
 with base_events as (
     select * from {{ ref('base_ga4__events')}}
-    {% if var('include_intraday_events', 'true') == 'true' %}
+    {% if var('include_intraday_events', false) %}
     union all
     select * from {{ref('base_ga4__events_intraday')}}
     {% endif %}


### PR DESCRIPTION
Added a new model, base_ga4__events_intraday which is conditionally enabled based on the variable `include_intraday_events`. 

If enabled, this model will be unioned with the events from past days loaded into the incremental model. 